### PR TITLE
Sentry

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,8 @@
     "FB_PAGE_ACCESS_TOKEN": {"required": true},
     "BRIGHTCOVE_ACCOUNT_ID": {"required": true},
     "SPOOR_API_KEY": {"required": true},
-    "SEGMENT_ID": {"required": true}
+    "SEGMENT_ID": {"required": true},
+    "SENTRY_DSN": {"required": true}
   },
   "addons": [
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "source scripts/env.sh && nodemon",
     "postinstall": "make",
     "test": "make test",
+    "heroku-config": "heroku-config-to-env -i HEROKU_ -i REDIS_URL -i NODE_ENV -l REDIS_URL=redis://localhost:6379/ ft-facebook-instant-staging scripts/env.sh",
     "watch": "wmake"
   },
   "repository": {
@@ -50,6 +51,7 @@
     "signed-aws-es-fetch": "^1.1.0"
   },
   "devDependencies": {
+    "@quarterto/heroku-config-to-env": "^1.3.1",
     "@quarterto/chai-dom-equal": "^1.0.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "morgan": "^1.7.0",
     "node-fetch": "^1.4.1",
     "nodemon": "^1.9.1",
+    "raven": "^0.10.0",
     "redis": "^2.5.1",
     "request": "^2.69.0",
     "s3o-middleware": "^1.4.0",

--- a/server/controllers/dev.js
+++ b/server/controllers/dev.js
@@ -83,6 +83,8 @@ module.exports = (req, res, next) => {
 			return res.render('cookies', {
 				cookies: JSON.stringify({cookies: req.cookies}, undefined, '\t'),
 			});
+		case 'throw':
+			throw new Error('lol');
 		default:
 			res.sendStatus(404);
 			break;

--- a/server/controllers/dev.js
+++ b/server/controllers/dev.js
@@ -85,6 +85,8 @@ module.exports = (req, res, next) => {
 			});
 		case 'throw':
 			throw new Error('lol');
+		case 'nexterror':
+			return next(new Error('lol'));
 		default:
 			res.sendStatus(404);
 			break;

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -6,6 +6,7 @@ const articleModel = require('../models/article');
 const transform = require('../lib/transform');
 const fbApi = require('../lib/fbApi');
 const ftApi = require('../lib/ftApi');
+const ravenClient = require('../lib/raven');
 
 const mode = require('../lib/mode').get();
 const UPDATE_INTERVAL = 1 * 60 * 1000;
@@ -67,7 +68,12 @@ const poller = () => Promise.all([
 		return database.setLastNotificationCheck(Date.now());
 	})
 )
-.catch(e => console.log(e.stack || e)); // TODO: error reporting
+.catch(e => {
+	console.error(e.stack || e);
+	if(mode === 'production') {
+		ravenClient.captureException(e, {tags: {from: 'notifications'}});
+	}
+});
 
 module.exports.init = () => {
 	poller();

--- a/server/index.js
+++ b/server/index.js
@@ -100,6 +100,10 @@ app.route('^/republish$').post(republishController.route);
 
 /* Errors */
 
+if(app.get('env') !== 'development') {
+	app.use(raven.middleware.express.errorHandler(ravenClient));
+}
+
 const logErrors = (error, req, res, next) => {
 	console.error('LOGERRORS', error.stack || error);
 	next(error);

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,6 @@ const favicon = require('serve-favicon');
 const path = require('path');
 const bodyParser = require('body-parser');
 const raven = require('raven');
-const os = require('os');
 const noCache = require('./lib/nocache');
 const devController = require('./controllers/dev');
 const indexController = require('./controllers/index');
@@ -33,13 +32,7 @@ let ravenClient;
 
 if(mode === 'production') {
 	assertEnv(['SENTRY_DSN']);
-	ravenClient = new raven.Client(process.env.SENTRY_DSN);
-	ravenClient.setExtraContext({env: process.env});
-	ravenClient.setTagsContext({
-		server_name: process.env.HEROKU_APP_NAME || os.hostname(),
-		release: process.env.HEROKU_SLUG_COMMIT,
-	});
-	ravenClient.patchGlobal(() => process.exit(1));
+	ravenClient = require('./lib/raven');
 }
 
 assertEnv([

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ const port = process.env.PORT || 6247;
 
 let ravenClient;
 
-if(mode === 'production') {
+if(app.get('env') !== 'development') {
 	assertEnv(['SENTRY_DSN']);
 	ravenClient = require('./lib/raven');
 }
@@ -50,7 +50,7 @@ assertEnv([
 	'SEGMENT_ID',
 ]);
 
-if(mode === 'production') {
+if(app.get('env') !== 'development') {
 	app.use(raven.middleware.express.requestHandler(ravenClient));
 	app.use((req, res, next) => {
 		ravenClient.setExtraContext(raven.parsers.parseRequest(req));

--- a/server/lib/raven.js
+++ b/server/lib/raven.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const raven = require('raven');
+const os = require('os');
+
+const ravenClient = new raven.Client(process.env.SENTRY_DSN);
+ravenClient.setExtraContext({env: process.env});
+ravenClient.setTagsContext({
+	server_name: process.env.HEROKU_APP_NAME || os.hostname(),
+	release: process.env.HEROKU_SLUG_COMMIT,
+});
+
+ravenClient.patchGlobal(() => process.exit(1));
+
+module.exports = ravenClient;


### PR DESCRIPTION
@georgecrawford the Sentry DSN is added to staging but not yet prod. I've also added `heroku-config-to-env` as an npm script, so you can just run `npm run heroku-config` to get `SENTRY_DSN` in your local config. All the controllers report to Sentry one way or another, which I think covers every promise codepath.
