### PR TITLE
Allow adding more auth tokens from fb

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,6 +11,7 @@
     "API_V1_KEY": {"required": true},
     "FB_PAGE_ID": {"required": true},
     "FB_APP_ID": {"required": true},
+    "FB_APP_SECRET": {"required": true},
     "FB_PAGE_ACCESS_TOKEN": {"required": true},
     "BRIGHTCOVE_ACCOUNT_ID": {"required": true},
     "SPOOR_API_KEY": {"required": true},

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ assertEnv([
 	'API_V1_KEY',
 	'FB_PAGE_ID',
 	'FB_APP_ID',
+	'FB_APP_SECRET',
 	'FB_PAGE_ACCESS_TOKEN',
 	'BRIGHTCOVE_ACCOUNT_ID',
 	'SPOOR_API_KEY',
@@ -91,6 +92,7 @@ app.route('^/article/:url/api$').get(apiController);
 
 // TODO: change these to post only, and remove debugging routes
 app.route(`^/article/:url/:mode(${mode})?/:action$`).all(noCache).all(articleController);
+
 
 // Dev-only routes
 app.route('^/dev/:action').get(noCache).get(devController);

--- a/server/lib/accessTokens.js
+++ b/server/lib/accessTokens.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const redisClient = require('./redisClient');
+
+let i = 0;
+
+exports.add = token => redisClient.saddAsync('meta:access_tokens', token);
+
+exports.get = () => redisClient.smembersAsync('meta:access_tokens')
+.then(tokens => {
+	const token = tokens[i];
+	i = (i + 1) % tokens.length;
+	return token;
+});
+
+exports.remove = token => redisClient.sremAsync('meta:access_tokens', token);
+
+exports.add(process.env.FB_PAGE_ACCESS_TOKEN)
+  .then(() => console.log(`${new Date()}:`, 'ACCESS TOKENS:', 'Added initial page token to Redis'));

--- a/server/lib/fbApi.js
+++ b/server/lib/fbApi.js
@@ -173,4 +173,5 @@ module.exports = {
 	delete: del,
 	find,
 	wipe,
+	call,
 };

--- a/views/templates/authfb.html
+++ b/views/templates/authfb.html
@@ -9,7 +9,7 @@
     // for FB.getLoginStatus().
     if (response.status === 'connected') {
       // Logged into your app and Facebook.
-      testAPI();
+      getPageAccessToken(response.authResponse.accessToken);
     } else if (response.status === 'not_authorized') {
       // The person is logged into Facebook, but not your app.
       document.getElementById('status').innerHTML = 'Please log ' +
@@ -69,13 +69,11 @@
 
   // Here we run a very simple test of the Graph API after login is
   // successful.  See statusChangeCallback() for when this call is made.
-  function testAPI() {
-    console.log('Welcome!  Fetching your information.... ');
-    FB.api('/me', function(response) {
-      console.log('Successful login for: ' + response.name);
-      document.getElementById('status').innerHTML =
-        'Thanks for logging in, ' + response.name + '!';
-    });
+  function getPageAccessToken(accessToken) {
+    $.get('/dev/pagetoken', {accessToken: accessToken}).then(
+      function(data) { docuent.getElementById(status).textContent = data },
+      function(xhr, status, error) { docuent.getElementById(status).textContent = error.stack || error.toString() },
+    )
   }
 </script>
 

--- a/views/templates/authfb.html
+++ b/views/templates/authfb.html
@@ -72,7 +72,7 @@
   function getPageAccessToken(accessToken) {
     $.get('/dev/pagetoken', {accessToken: accessToken}).then(
       function(data) { docuent.getElementById(status).textContent = data },
-      function(xhr, status, error) { docuent.getElementById(status).textContent = error.stack || error.toString() },
+      function(xhr, status, error) { docuent.getElementById(status).textContent = error.stack || error.toString() }
     )
   }
 </script>

--- a/views/templates/authfb.html
+++ b/views/templates/authfb.html
@@ -1,0 +1,92 @@
+<script>
+  // This is called with the results from from FB.getLoginStatus().
+  function statusChangeCallback(response) {
+    console.log('statusChangeCallback');
+    console.log(response);
+    // The response object is returned with a status field that lets the
+    // app know the current login status of the person.
+    // Full docs on the response object can be found in the documentation
+    // for FB.getLoginStatus().
+    if (response.status === 'connected') {
+      // Logged into your app and Facebook.
+      testAPI();
+    } else if (response.status === 'not_authorized') {
+      // The person is logged into Facebook, but not your app.
+      document.getElementById('status').innerHTML = 'Please log ' +
+        'into this app.';
+    } else {
+      // The person is not logged into Facebook, so we're not sure if
+      // they are logged into this app or not.
+      document.getElementById('status').innerHTML = 'Please log ' +
+        'into Facebook.';
+    }
+  }
+
+  // This function is called when someone finishes with the Login
+  // Button.  See the onlogin handler attached to it in the sample
+  // code below.
+  function checkLoginState() {
+    FB.getLoginStatus(function(response) {
+      statusChangeCallback(response);
+    });
+  }
+
+  window.fbAsyncInit = function() {
+  FB.init({
+    appId      : '{{fbAppId}}',
+    cookie     : true,  // enable cookies to allow the server to access
+                        // the session
+    xfbml      : true,  // parse social plugins on this page
+    version    : 'v2.5' // use graph api version 2.5
+  });
+
+  // Now that we've initialized the JavaScript SDK, we call
+  // FB.getLoginStatus().  This function gets the state of the
+  // person visiting this page and can return one of three states to
+  // the callback you provide.  They can be:
+  //
+  // 1. Logged into your app ('connected')
+  // 2. Logged into Facebook, but not your app ('not_authorized')
+  // 3. Not logged into Facebook and can't tell if they are logged into
+  //    your app or not.
+  //
+  // These three cases are handled in the callback function.
+
+  FB.getLoginStatus(function(response) {
+    statusChangeCallback(response);
+  });
+
+  };
+
+  // Load the SDK asynchronously
+  (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = "//connect.facebook.net/en_US/sdk.js";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));
+
+  // Here we run a very simple test of the Graph API after login is
+  // successful.  See statusChangeCallback() for when this call is made.
+  function testAPI() {
+    console.log('Welcome!  Fetching your information.... ');
+    FB.api('/me', function(response) {
+      console.log('Successful login for: ' + response.name);
+      document.getElementById('status').innerHTML =
+        'Thanks for logging in, ' + response.name + '!';
+    });
+  }
+</script>
+
+<!--
+  Below we include the Login Button social plugin. This button uses
+  the JavaScript SDK to present a graphical Login button that triggers
+  the FB.login() function when clicked.
+-->
+
+<fb:login-button scope="pages_manage_instant_articles,pages_show_list,read_insights" onlogin="checkLoginState();">
+</fb:login-button>
+
+<div id="status">
+</div>


### PR DESCRIPTION
Not yet tested end to end, but the individual bits seem to work.
1. Store a set of page tokens in Redis. The env var page token is added on startup (this is idempotent).
2. Unless you provide an explicit access token for FB, grab the next page token from the set and use that.
3. Add a route to request a page token from a user token and store it in Redis.
4. Add a route to display an FB login dialog, and turn that token into a page token automagically.
