### PR TITLE
Fix republish

### DIFF
--- a/server/controllers/updateRepublish.js
+++ b/server/controllers/updateRepublish.js
@@ -9,7 +9,8 @@ const {version} = require('../../package.json');
 const mode = require('../lib/mode').get();
 
 const update = (article, {onlyAfterRedeploy = true} = {}) => {
-	const publishedByOldVersion = article.import_meta[0] && article.import_meta[0].appVersion !== version;
+	const isDevelopment = version === '0.0.0-development';
+	const publishedByOldVersion = !isDevelopment && article.import_meta[0] && article.import_meta[0].appVersion !== version;
 	const shouldRepublish = !onlyAfterRedeploy || publishedByOldVersion;
 	const sentToFacebook = (article.fbRecords[mode] && !article.fbRecords[mode].nullRecord);
 	if(sentToFacebook && shouldRepublish) {


### PR DESCRIPTION
Currently republish happens when you start the server locally, and if a single article fails halfway through you end up with half the articles published from one version and half from another
