### PR TITLE
enforce node version on prestart

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facebook Instant Articles",
   "main": "build/index.js",
   "scripts": {
-    "prestart": "wmake babel &",
+    "prestart": "enforce-node-version && wmake babel &",
     "start": "source scripts/env.sh && nodemon",
     "postinstall": "make",
     "test": "make test",
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/Financial-Times/ft-facebook-instant#readme",
   "dependencies": {
     "@quarterto/assert-env": "^1.1.0",
+    "@quarterto/enforce-node-version": "^1.1.0",
     "@quarterto/heroku-version-infer": "^3.2.3",
     "@quarterto/package-version-github-release": "^1.0.0",
     "@quarterto/package-version-jira-release": "^1.1.0",


### PR DESCRIPTION
master doesn't have an `engines` field so it's just skipped for now, but #153 adds it
