### PR TITLE
fix light signup default url

### DIFF
--- a/server/lib/transform.js
+++ b/server/lib/transform.js
@@ -87,7 +87,7 @@ module.exports = article => {
 		date_published: article.date_editorially_published,
 		date_updated: article.date_record_updated,
 		cookieChecker: (process.env.SHOW_COOKIE_CHECKER && process.env.NODE_ENV !== 'production'),
-		lightSignupUrl: process.env.LIGHT_SIGNUP_URL || 'https://distro-light-signup-prod.herokuapp.com',
+		lightSignupUrl: process.env.LIGHT_SIGNUP_URL || 'https://distro-light-signup.ft.com',
 		lightSignupProduct,
 		lightSignupMailinglist,
 		enableLightSignup: (process.env.ENABLE_LIGHT_SIGNUP === 'true'),


### PR DESCRIPTION
don't think this has affected anything because all the servers set their url but it's good to make sure
