### PR TITLE
Make it better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ insights/*
 redis.conf
 .eslintcache
 env.mk
+tmp

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ TEST_UTILS = $(shell find test-utils -name '*.js')
 INTEGRATION_FILES = $(shell find $(INTEGRATION) -name '*.js')
 INTEGRATION_DIRS = $(dir $(INTEGRATION_FILES))
 
-NPM_BIN := $(shell npm bin)
+NPM_BIN := node_modules/.bin
 
 BABEL = $(NPM_BIN)/babel
 BABEL_OPTS =

--- a/makefile
+++ b/makefile
@@ -6,55 +6,19 @@ ifdef HEROKU
 	-include scripts/env.mk
 endif
 
-SRC = server
-LIB = build
-TEST = test
-INTEGRATION = integration
-SRC_FILES = $(shell find $(SRC) -name '*.js')
-LIB_FILES = $(patsubst $(SRC)/%.js, $(LIB)/%.js, $(SRC_FILES))
-LIB_DIRS = $(dir $(LIB_FILES))
-TEST_FILES = $(shell find $(TEST) -name '*.js')
-TEST_DIRS = $(dir $(TEST_FILES))
-TEST_UTILS = $(shell find test-utils -name '*.js')
-INTEGRATION_FILES = $(shell find $(INTEGRATION) -name '*.js')
-INTEGRATION_DIRS = $(dir $(INTEGRATION_FILES))
-
-NPM_BIN := node_modules/.bin
-
-BABEL = $(NPM_BIN)/babel
-BABEL_OPTS =
-
-ESLINT = $(NPM_BIN)/eslint
-ESLINT_OPTS = --fix
-
-LINTSPACE = $(NPM_BIN)/lintspaces
-LINTSPACE_OPTS = -n -d tabs -l 2
-
-MOCHA = $(NPM_BIN)/mocha
-MOCHA_OPTS = --compilers js:babel-register --no-timeouts
-
-HEROKU_CONFIG_TO_ENV = $(NPM_BIN)/heroku-config-to-env
-HEROKU_CONFIG_OPTS = -i HEROKU_ -i REDIS_URL -i NODE_ENV -l REDIS_URL=redis://localhost:6379/ -l NODE_ENV=development
-HEROKU_CONFIG_APP = ft-facebook-instant-staging
+include vars.mk
 
 all: babel
 
-babel: $(LIB) $(LIB_DIRS) $(LIB_FILES)
+babel: $(LIB_FILES)
 
-$(LIB)/%.js: $(SRC)/%.js
-	$(BABEL) $(BABEL_OPTS) $< -o $@
+$(LIB)/%.js: tmp/$(SRC)/%.js
+	@mkdir -p $(@D)
+	@cp $< $@
 
-$(LIB)/%: $(SRC)/% clean-$(LIB)/%
-	mkdir -p $@
-
-$(LIB): $(SRC)
-	mkdir -p $@
-
-clean-$(LIB)/%:
-	$(eval LIB_THINGS := $(patsubst $(LIB)/%, %, $(wildcard $(LIB)/$*/*)))
-	$(eval SRC_THINGS := $(patsubst $(SRC)/%, %, $(wildcard $(SRC)/$*/*)))
-	$(eval TO_DELETE := $(addprefix $(LIB)/, $(shell comm -23 <(echo $(LIB_THINGS) | tr ' ' '\n' | sort) <(echo $(SRC_THINGS) | tr ' ' '\n' | sort))))
-	$(if $(TO_DELETE), rm -rf $(TO_DELETE))
+tmp/$(SRC)/%.js: $(SRC)/%.js
+	$(eval changed-files := $(shell make -f newer.mk | grep -v 'Nothing to be done'))
+	$(if $(changed-files), $(BABEL) $(BABEL_OPTS) --out-dir tmp $(changed-files))
 
 clean:
 	rm -rf $(LIB)

--- a/newer.mk
+++ b/newer.mk
@@ -1,0 +1,6 @@
+include vars.mk
+
+all: $(LIB_FILES)
+
+$(LIB)/%.js: $(SRC)/%.js
+	@echo $<

--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "proxyquire": "^1.7.9",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
-    "watch-make": "^1.0.0"
+    "watch-make": "^2.0.1"
   }
 }

--- a/vars.mk
+++ b/vars.mk
@@ -1,0 +1,30 @@
+SRC = server
+LIB = build
+TEST = test
+INTEGRATION = integration
+SRC_FILES = $(shell find $(SRC) -name '*.js')
+LIB_FILES = $(patsubst $(SRC)/%.js, $(LIB)/%.js, $(SRC_FILES))
+LIB_DIRS = $(dir $(LIB_FILES))
+TEST_FILES = $(shell find $(TEST) -name '*.js')
+TEST_DIRS = $(dir $(TEST_FILES))
+TEST_UTILS = $(shell find test-utils -name '*.js')
+INTEGRATION_FILES = $(shell find $(INTEGRATION) -name '*.js')
+INTEGRATION_DIRS = $(dir $(INTEGRATION_FILES))
+
+NPM_BIN := node_modules/.bin
+
+BABEL = $(NPM_BIN)/babel
+BABEL_OPTS =
+
+ESLINT = $(NPM_BIN)/eslint
+ESLINT_OPTS = --fix
+
+LINTSPACE = $(NPM_BIN)/lintspaces
+LINTSPACE_OPTS = -n -d tabs -l 2
+
+MOCHA = $(NPM_BIN)/mocha
+MOCHA_OPTS = --compilers js:babel-register --no-timeouts
+
+HEROKU_CONFIG_TO_ENV = $(NPM_BIN)/heroku-config-to-env
+HEROKU_CONFIG_OPTS = -i HEROKU_ -i REDIS_URL -i NODE_ENV -l REDIS_URL=redis://localhost:6379/ -l NODE_ENV=development
+HEROKU_CONFIG_APP = ft-facebook-instant-staging


### PR DESCRIPTION
- watch-make 2, rewritten in javascript:
  - much much faster
  - doesn't leave subprocesses running if killed at the wrong point
  - doesn't use the combination of make flags that was inadvertently clobbering env.sh
  - much better at handling make errors
  - pretty output
- single pass babel compilation, gets a list of changed files first then passes all of them to babel in one invocation
